### PR TITLE
Abstract actual creation of purchase from validation

### DIFF
--- a/edd-manual-purchases.php
+++ b/edd-manual-purchases.php
@@ -411,6 +411,12 @@ class EDD_Manual_Purchases {
 
 	}
 
+	/**
+	 * Make a payment
+	 *
+	 * @param array $data Purchase data
+	 * @param WP_User $user User object
+	 */
 	public static function make_payment( $data, $user ) {
 		global $edd_options;
 
@@ -428,11 +434,6 @@ class EDD_Manual_Purchases {
 
 			)
 		);
-
-
-
-
-
 
 		$user_id 	= $user ? $user->ID : 0;
 		$email 		= $user ? $user->user_email : strip_tags( trim( $data['user'] ) );


### PR DESCRIPTION
I created a new method for creating payments, that has the validation, and pulling of data from POST removed. It is called by the existing `create_payment()` method for backwards-compat and so that nonce check, etc still happens.