### PR TITLE
Allow purchase receipts to not be sent when creating purchases

### DIFF
--- a/edd-manual-purchases.php
+++ b/edd-manual-purchases.php
@@ -784,13 +784,13 @@ class EDD_Manual_Purchases {
 
 			$payment->save();
 
+			if( ! isset( $data['receipt'] ) ) {
+				remove_action( 'edd_complete_purchase', 'edd_trigger_purchase_receipt', 999 );
+			}
+
 			if ( isset( $_POST['status'] ) && 'pending' !== $_POST['status'] ) {
 				$payment->status = $_POST['status'];
 				$payment->save();
-			}
-
-			if( empty( $data['receipt'] ) || $data['receipt'] != '1' ) {
-				remove_action( 'edd_complete_purchase', 'edd_trigger_purchase_receipt', 999 );
 			}
 
 			if( ! empty( $data['wallet'] ) && class_exists( 'EDD_Wallet' ) && $user_id > 0 ) {


### PR DESCRIPTION
Fixes #53. Purchase receipt was still sending even if the checkbox to send it was not checked. For some reason moving this remove_action() up higher got it working. Also simplified the logic. Checkboxes aren't sent to the server at all if they're not checked so we only to check if it is set.